### PR TITLE
Fix DoD formatting again

### DIFF
--- a/.github/ISSUE_TEMPLATE/tasks.yaml
+++ b/.github/ISSUE_TEMPLATE/tasks.yaml
@@ -31,8 +31,8 @@ body:
     attributes:
       label: Definition of Done
       description: Provide an easy to understand definition of done for each task
-      placeholder: "- [] A"
-      value: "- [] Task A is done when..."
+      placeholder: "- [ ] A"
+      value: "- [ ] Task A is done when..."
     validations:
       required: false
   - type: checkboxes


### PR DESCRIPTION
I missed that there weren't spaces between the brackets in #23 ...

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] no
- [ ] yes (*bugfixes and features will not be merged without tests*)

Breaking Changes?
- [ ] no
- [ ] yes (*breaking changes will not be merged unless absolutely necessary – please provide motivation*)

List any relevant issue numbers:
Follow up to #23.

### Description

In #23 the necessary `-` was added before the `[]`, but I missed that the brackets didn't have the necessary space between them.